### PR TITLE
fix `getSmartAgentAuthHeaders` export and move into own namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,9 @@ export { Container, ContainerConfig, ContainerFile, ContainerTemplate, Container
   ContainerShareConfig, ContainerOptions, } from './contracts/digital-twin/container';
 export { DigitalTwin, DigitalTwinEntryType, DigitalTwinConfig, DigitalTwinIndexEntry,
   DigitalTwinVerificationEntry, } from './contracts/digital-twin/digital-twin';
+import { getSmartAgentAuthHeaders } from './common/utils';
+const utils = { getSmartAgentAuthHeaders };
+export { utils };
 
 /******** export these libraries to be able to build the blockchain-core into an umd bundle ********/
 import Web3 = require('web3');


### PR DESCRIPTION
- [CORE-23]

[CORE-23]: https://evannetwork.atlassian.net/browse/CORE-23