### PR TITLE
Feature/core 1276 identity runtime mnemonic

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -14,6 +14,7 @@
   + `Votings`
 - addded `EvanIdentity` as authorization parameter to result of `utils.getSmartAgentAuthHeaders` (for usage sample have a look to [edge-server-seed](https://github.com/evannetwork/edge-server-seed/tree/develop#auth-middleware))
 - add `Identity` class and add functions for grant / remove access to act on behalf of identity
+- support identity salting for encryptionKey generation for `createDefaultRuntime`
 
 ### Fixes
 - Fixed bug where a new DID document proof would incorporate the old proof and thus would make the document increasingly larger

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -26,6 +26,7 @@
 - use `useIdentity` flag for `createOfflineProfile`
 - pass `password` to `createOfflineProfile` to enable dataKey generation based on the users identity
 - checked node 13 compatibility
+- reset executor signer for runtime initialization with account that has no identity
 
 ### Deprecations
 

--- a/src/onboarding.spec.ts
+++ b/src/onboarding.spec.ts
@@ -88,7 +88,8 @@ describe('Onboarding helper', function test() {
       },
     });
     expect(newProfile).to.be.exist;
-    expect(newProfile.runtimeConfig).to.be.deep.eq(runtimeConfig);
+    expect(newProfile.runtimeConfig.accountMap).to.be.deep.eq(runtimeConfig.accountMap);
+    expect(newProfile.runtimeConfig.keyConfig).to.be.deep.eq(runtimeConfig.keyConfig);
   });
 
   it('should create a new profile from a different account', async () => {
@@ -103,7 +104,8 @@ describe('Onboarding helper', function test() {
       },
     });
 
-    expect(newProfile.runtimeConfig).to.be.deep.eq(runtimeConfig);
+    expect(newProfile.runtimeConfig.accountMap).to.be.deep.eq(runtimeConfig.accountMap);
+    expect(newProfile.runtimeConfig.keyConfig).to.be.deep.eq(runtimeConfig.keyConfig);
   });
 
   it.skip('should be able to send an invitation via smart agent', async () => {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -101,11 +101,11 @@ export class Onboarding extends Logger {
     if (!password) {
       throw new Error('password is a required parameter!');
     }
-
-    const runtimeConfig: any = await Onboarding.generateRuntimeConfig(
-      mnemonic, password, runtime.web3,
-    );
-    const runtimeNew = await createDefaultRuntime(runtime.web3, runtime.dfs, runtimeConfig);
+    const runtimeNew = await createDefaultRuntime(runtime.web3, runtime.dfs, {
+      mnemonic,
+      password,
+      useIdentity: runtime.runtimeConfig.useIdentity,
+    });
 
     // check if the source runtime has enough funds
     const profileCost = runtime.web3.utils.toWei('1.0097');
@@ -135,7 +135,7 @@ export class Onboarding extends Logger {
     return {
       mnemonic,
       password,
-      runtimeConfig,
+      runtimeConfig: runtimeNew.runtimeConfig,
     };
   }
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -302,11 +302,18 @@ export class Onboarding extends Logger {
   /**
    * generates a runtime config for a given mneomic and password
    *
-   * @param      {string}  mnemonic  specified mnemonic
-   * @param      {string}  password  given password
-   * @param      {any}     web3      web3 instance
+   * @param      {string}  mnemonic         specified mnemonic
+   * @param      {string}  password         given password
+   * @param      {any}     web3             web3 instance
+   * @param      {string}  passwordSalting  string that should be used for encryptionKey salting
+   *                                        instead of account id (e.g. identity)
    */
-  public static async generateRuntimeConfig(mnemonic: string, password: string, web3: any) {
+  public static async generateRuntimeConfig(
+    mnemonic: string,
+    password: string,
+    web3: any,
+    passwordSalting?: string,
+  ) {
     // generate a new vault from the mnemnonic and the password
     const vault: any = await new Promise((res) => {
       KeyStore.createVault({
@@ -331,7 +338,7 @@ export class Onboarding extends Logger {
       [web3.utils.soliditySha3(accountId), web3.utils.soliditySha3(accountId)].sort());
     const sha3Account = web3.utils.soliditySha3(accountId);
     const dataKey = web3.utils
-      .keccak256(accountId + password)
+      .keccak256((passwordSalting || accountId) + password)
       .replace(/0x/g, '');
     const runtimeConfig = {
       accountMap: {

--- a/src/runtime.spec.ts
+++ b/src/runtime.spec.ts
@@ -20,11 +20,12 @@
 import 'mocha';
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import { cloneDeep } from 'lodash';
 
 import { createDefaultRuntime, getRuntimeForIdentity } from './runtime';
 import { TestUtils } from './test/test-utils';
 import {
-  accountMap, accounts, useIdentity, identities, dataKeys,
+  accountMap, useIdentity, identities, dataKeys,
 } from './test/accounts';
 
 use(chaiAsPromised);
@@ -42,26 +43,32 @@ describe('Runtime', function test() {
       // use an mnemonic with accountId encryption salting
       {
         accountId: '0xE88eC34914f423761073458DcA3F16d6d7E8c6Cf',
+        encryptionKey: '6d3bcfb8ff2fde2f10fcd79574435b32aee0268c1e2103d2132a0ac18511e11e',
         identity: '0x617Cbb36a12ab15e83Cca471D4008E55A411c6aD',
         mnemonic: 'retire plunge spring current album shiver network bicycle equal burden able code',
-        password: 'Test1234',
+        password: 'Evan1234',
+        privateKey: '23358a2c345baefdc1144258c3e23ab6619ee14ca67ce1244e82176ac467d943',
       },
       // use an mnemonic with identity address encryption salting
       {
         accountId: '0xb6D7f0C3A88dDfF426cdcF6cE1666978844b9ba1',
+        encryptionKey: 'fc543dda9394705bcfbe7e3c9abe77f06a5952e938964d3150bae9ea07400ea3',
         identity: '0x82c436230BfBE4D9F88d20d2E1F5C697E9dC4091',
         mnemonic: 'window ivory shoe toward mammal link lecture cliff shadow holiday force view',
         password: 'Test1234',
+        privateKey: '5e03d038960aab7e80f80bef7706d562e1133a4e7c44ee3483e9576442e7f2f8',
       },
     ];
   } else {
     // use an mnemonic for an old account
     mnemonicAndPasswords = [
       {
+        accountId: '0x1cf81039Cd6dFbeD999586Ac3B21963C0275E6D7',
+        encryptionKey: 'b36f9f9e598deaac8bf7219a283c798e3000c526bb2b3fae9e8219e7fdace362',
+        identity: '0x1cf81039Cd6dFbeD999586Ac3B21963C0275E6D7',
         mnemonic: 'annual lyrics orbit slight object space jeans ethics broccoli umbrella entry couch',
         password: 'Test1234',
-        accountId: '0x1cf81039Cd6dFbeD999586Ac3B21963C0275E6D7',
-        identity: '0x1cf81039Cd6dFbeD999586Ac3B21963C0275E6D7',
+        privateKey: 'dfb9d2c5be6e7123fa1e1c9fe82becdb0adfb3561b18e4bc79e4cfa549b8ca46',
       },
     ];
   }
@@ -107,33 +114,25 @@ describe('Runtime', function test() {
     expect(switchedRuntime.profile).to.be.not.null;
   });
 
-  it('should create a new runtime and parse accountid and password in accountMap', async () => {
-    for (const loginData of mnemonicAndPasswords) {
-      const tmpRuntimeConfig = JSON.parse(JSON.stringify(runtimeConfig));
-      tmpRuntimeConfig.accountMap = {
-        [loginData.account]: loginData.password,
-      };
-      const runtime = await createDefaultRuntime(web3, dfs, tmpRuntimeConfig);
-      expect(runtime).to.be.ok;
-      expect(runtime.profile).to.be.not.null;
-      expect(runtime.profile.activeAccount).to.be
-        .eq(useIdentity ? loginData.identity : loginData.account);
-      expect(runtime.activeIdentity).to.be.eq(identities[0]);
-    }
-  });
-
   it('should create a new runtime and parse accountid and password in keyConfig', async () => {
     for (const loginData of mnemonicAndPasswords) {
-      const tmpRuntimeConfig = JSON.parse(JSON.stringify(runtimeConfig));
+      const tmpRuntimeConfig = cloneDeep(runtimeConfig);
+      tmpRuntimeConfig.accountMap = {
+        [loginData.accountId]: loginData.privateKey,
+      };
       tmpRuntimeConfig.keyConfig = {
-        [loginData.account]: loginData.password,
+        [loginData.accountId]: loginData.password,
       };
       const runtime = await createDefaultRuntime(web3, dfs, tmpRuntimeConfig);
+      const sha3Account = web3.utils.soliditySha3(loginData.accountId);
+      const sha9Account = web3.utils.soliditySha3(sha3Account, sha3Account);
       expect(runtime).to.be.ok;
       expect(runtime.profile).to.be.not.null;
-      expect(runtime.profile.activeAccount).to.be
-        .eq(useIdentity ? loginData.identity : loginData.account);
-      expect(runtime.activeIdentity).to.be.eq(identities[0]);
+      expect(runtime.activeIdentity).to.be.eq(
+        useIdentity ? loginData.identity : loginData.accountId,
+      );
+      expect(runtime.runtimeConfig.keyConfig[sha3Account]).to.be.eq(loginData.encryptionKey);
+      expect(runtime.runtimeConfig.keyConfig[sha9Account]).to.be.eq(loginData.encryptionKey);
     }
   });
 
@@ -144,26 +143,53 @@ describe('Runtime', function test() {
         password: loginData.password,
         useIdentity,
       });
+      const sha3Account = web3.utils.soliditySha3(loginData.accountId);
+      const sha9Account = web3.utils.soliditySha3(sha3Account, sha3Account);
       expect(runtime).to.be.ok;
       expect(runtime.profile).to.be.not.null;
-      expect(runtime.profile.activeAccount).to.be
-        .eq(useIdentity ? loginData.identity : loginData.account);
+      expect(runtime.activeIdentity).to.be.eq(
+        useIdentity ? loginData.identity : loginData.accountId,
+      );
+      expect(runtime.runtimeConfig.accountMap[loginData.accountId]).to.be.eq(loginData.privateKey);
+      expect(runtime.runtimeConfig.keyConfig[sha3Account]).to.be.eq(loginData.encryptionKey);
+      expect(runtime.runtimeConfig.keyConfig[sha9Account]).to.be.eq(loginData.encryptionKey);
     }
   });
 
+
   it('should create a new and valid runtime with a mnemonic and a password and merge with given accounts', async () => {
+    const expectedKeyNum = useIdentity ? 18 : 17;
     for (const loginData of mnemonicAndPasswords) {
-      const expectedKeyNum = useIdentity ? 18 : 17;
-      const tmpRuntimeConfig = runtimeConfig;
-      tmpRuntimeConfig.mnemonic = loginData.mnemonic;
-      tmpRuntimeConfig.password = loginData.password;
-      const runtime = await createDefaultRuntime(web3, dfs, tmpRuntimeConfig);
+      const runtime = await createDefaultRuntime(web3, dfs, {
+        mnemonic: loginData.mnemonic,
+        password: loginData.password,
+        ...runtimeConfig,
+        useIdentity,
+      });
+      const sha3Account = web3.utils.soliditySha3(loginData.accountId);
+      const sha9Account = web3.utils.soliditySha3(sha3Account, sha3Account);
       expect(runtime).to.be.ok;
       expect(runtime.profile).to.be.not.null;
-      expect(runtime.profile.activeAccount).to.be
-        .eq(useIdentity ? loginData.identity : loginData.account);
+      expect(runtime.activeIdentity).to.be.eq(
+        useIdentity ? loginData.identity : loginData.accountId,
+      );
+      expect(runtime.runtimeConfig.accountMap[loginData.accountId]).to.be.eq(loginData.privateKey);
+      expect(runtime.runtimeConfig.keyConfig[sha3Account]).to.be.eq(loginData.encryptionKey);
+      expect(runtime.runtimeConfig.keyConfig[sha9Account]).to.be.eq(loginData.encryptionKey);
       expect(Object.keys(runtime.keyProvider.keys).length).to.eq(expectedKeyNum);
     }
+  });
+
+  it('should throw an error by passing a invalid password', async () => {
+    const runtimePromise = createDefaultRuntime(web3, dfs, {
+      mnemonic: mnemonicAndPasswords[0].mnemonic,
+      password: 'this is a wrong password',
+      ...runtimeConfig,
+      useIdentity,
+    });
+    await expect(runtimePromise).to.be.rejectedWith(
+      `incorrect password for ${mnemonicAndPasswords[0].accountId} passed to keyConfig`,
+    );
   });
 
   it('should NOT create a new and valid runtime with only passing mnemonic and empty account map', async () => {

--- a/src/runtime.spec.ts
+++ b/src/runtime.spec.ts
@@ -192,6 +192,14 @@ describe('Runtime', function test() {
     );
   });
 
+  it('use fallback encryptionKey salting for non initialized identities', async () => {
+    const runtimePromise = createDefaultRuntime(web3, dfs, {
+      mnemonic: 'annual lyrics orbit slight object space jeans ethics broccoli umbrella entry couch',
+      accountMap: { },
+    });
+    await expect(runtimePromise).to.be.rejected;
+  });
+
   it('should NOT create a new and valid runtime with only passing mnemonic and empty account map', async () => {
     const runtimePromise = createDefaultRuntime(web3, dfs, {
       mnemonic: 'annual lyrics orbit slight object space jeans ethics broccoli umbrella entry couch',

--- a/src/runtime.spec.ts
+++ b/src/runtime.spec.ts
@@ -158,7 +158,7 @@ describe('Runtime', function test() {
 
 
   it('should create a new and valid runtime with a mnemonic and a password and merge with given accounts', async () => {
-    const expectedKeyNum = useIdentity ? 18 : 17;
+    const expectedKeyNum = useIdentity ? 18 : 16;
     for (const loginData of mnemonicAndPasswords) {
       const runtime = await createDefaultRuntime(web3, dfs, {
         mnemonic: loginData.mnemonic,
@@ -180,7 +180,7 @@ describe('Runtime', function test() {
     }
   });
 
-  it('should throw an error by passing a invalid password', async () => {
+  (useIdentity ? it : it.skip)('should throw an error by passing a invalid password', async () => {
     const runtimePromise = createDefaultRuntime(web3, dfs, {
       mnemonic: mnemonicAndPasswords[0].mnemonic,
       password: 'this is a wrong password',

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -283,6 +283,7 @@ async function createRuntime(
       activeIdentity = activeAccount;
       underlyingAccount = activeIdentity;
       signer = signerInternal;
+      executor.signer = signerInternal;
     }
   } else {
     activeIdentity = activeAccount;
@@ -623,6 +624,9 @@ export async function createDefaultRuntime(
     Object.assign(runtimeConfig.keyConfig, {
       [runtimeConfig.account]: runtimeConfig.password,
     });
+    // cleanup runtime
+    delete runtimeConfig.mnemonic;
+    delete runtimeConfig.password;
   } else if (!runtimeConfig.accountMap
        || !(Object.keys(runtimeConfig.accountMap).length)) {
     throw new Error('accountMap invalid');

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -42,7 +42,7 @@ import { DataContract } from './contracts/data-contract/data-contract';
 import { Description } from './shared-description';
 import { Did } from './did/did';
 import { EncryptionWrapper } from './encryption/encryption-wrapper';
-import { getEnvironment } from './common/utils';
+import { getEnvironment, nullAddress } from './common/utils';
 import { Identity } from './identity/identity';
 import { Ipfs } from './dfs/ipfs';
 import { IpfsLib } from './dfs/ipfs-lib';
@@ -111,7 +111,7 @@ export interface Runtime {
  * @param      {any}               runtimeConfig  configuration values
  * @return     {Promise<Runtime>}  runtime instance
  */
-export async function createDefaultRuntime(
+async function createRuntime(
   web3: any, dfs: DfsInterface, runtimeConfig: any, options: Runtime = { },
 ): Promise<Runtime> {
   // determine chain this runtime is created for
@@ -160,30 +160,7 @@ export async function createDefaultRuntime(
   }
 
   // web3 contract interfaces
-  const contractLoader = options.contractLoader
-    || new ContractLoader({ contracts, log, web3 });
-
-  // check if mnemonic and password are given
-  if (runtimeConfig.mnemonic && runtimeConfig.password) {
-    const tempConfig: any = await Onboarding.generateRuntimeConfig(
-      runtimeConfig.mnemonic,
-      runtimeConfig.password,
-      web3,
-    );
-    if (!runtimeConfig.accountMap) {
-      // eslint-disable-next-line no-param-reassign
-      (runtimeConfig as any).accountMap = {};
-    }
-    if (!runtimeConfig.keyConfig) {
-      // eslint-disable-next-line no-param-reassign
-      (runtimeConfig as any).keyConfig = {};
-    }
-    Object.assign(runtimeConfig.accountMap, tempConfig.accountMap);
-    Object.assign(runtimeConfig.keyConfig, tempConfig.keyConfig);
-  } else if (!runtimeConfig.accountMap
-       || !(Object.keys(runtimeConfig.accountMap).length)) {
-    throw new Error('accountMap invalid');
-  }
+  const contractLoader = options.contractLoader || new ContractLoader({ contracts, log, web3 });
 
   // executor
   const accountStore = options.accountStore
@@ -249,30 +226,7 @@ export async function createDefaultRuntime(
   (cryptoConfig as any).aesEcb = new AesEcb({ log });
   const cryptoProvider = new CryptoProvider(cryptoConfig);
 
-  // check and modify if any accountid with password is provided
-  if (runtimeConfig.keyConfig) {
-    for (const accountId in runtimeConfig.keyConfig) {
-      // check if the key is a valid accountId
-      if (accountId.length === 42) {
-        const sha3Account = web3.utils.soliditySha3(accountId);
-        const sha9Account = web3.utils.soliditySha3(sha3Account, sha3Account);
-        const dataKey = web3.utils
-          .keccak256(accountId + runtimeConfig.keyConfig[accountId])
-          .replace(/0x/g, '');
-        // now add the different hashed accountids and datakeys to the runtimeconfig
-        // eslint-disable-next-line no-param-reassign
-        runtimeConfig.keyConfig[sha3Account] = dataKey;
-        // eslint-disable-next-line no-param-reassign
-        runtimeConfig.keyConfig[sha9Account] = dataKey;
-
-        // at least delete the old key
-        // eslint-disable-next-line no-param-reassign
-        delete runtimeConfig.keyConfig[accountId];
-      }
-    }
-  }
-
-  const activeAccount = Object.keys(runtimeConfig.accountMap)[0];
+  const activeAccount = runtimeConfig.account || Object.keys(runtimeConfig.accountMap)[0];
   const keyProvider = options.keyProvider
     || new KeyProvider({ keys: runtimeConfig.keyConfig, log });
   keyProvider.currentAccountHash = nameResolver.soliditySha3(activeAccount);
@@ -629,6 +583,122 @@ export async function createDefaultRuntime(
     ...(vc && { vc }),
     ...(underlyingAccount && { underlyingAccount }),
   };
+}
+
+/**
+ * create new runtime instance
+ *
+ * @param      {any}               web3           connected web3 instance
+ * @param      {DfsInterface}      dfs            interface for retrieving file from dfs
+ * @param      {any}               runtimeConfig  configuration values
+ * @return     {Promise<Runtime>}  runtime instance
+ */
+export async function createDefaultRuntime(
+  web3: any, dfs: DfsInterface, orgRuntimeConfig: any, options: Runtime = { },
+): Promise<Runtime> {
+  const runtimeConfig = cloneDeep(orgRuntimeConfig);
+  let contextLessRuntime;
+
+  // check if mnemonic and password are given
+  if (runtimeConfig.mnemonic && runtimeConfig.password) {
+    const tempConfig: any = await Onboarding.generateRuntimeConfig(
+      runtimeConfig.mnemonic,
+      runtimeConfig.password,
+      web3,
+    );
+    // eslint-disable-next-line prefer-destructuring
+    runtimeConfig.account = Object.keys(tempConfig.accountMap)[0];
+    if (!runtimeConfig.accountMap) {
+      // eslint-disable-next-line no-param-reassign
+      (runtimeConfig as any).accountMap = {};
+    }
+    if (!runtimeConfig.keyConfig) {
+      // eslint-disable-next-line no-param-reassign
+      (runtimeConfig as any).keyConfig = {};
+    }
+    Object.assign(runtimeConfig.accountMap, tempConfig.accountMap);
+    // do not apply the encryption key directly, will be handled by keyConfig account + password
+    // handling
+    Object.assign(runtimeConfig.keyConfig, {
+      [runtimeConfig.account]: runtimeConfig.password,
+    });
+  } else if (!runtimeConfig.accountMap
+       || !(Object.keys(runtimeConfig.accountMap).length)) {
+    throw new Error('accountMap invalid');
+  }
+
+  // check and modify if any accountid with password is provided
+  if (runtimeConfig.keyConfig) {
+    const accountIds = Object.keys(runtimeConfig.keyConfig);
+    await Promise.all(accountIds.map(async (accountId: string) => {
+      // check if the key is a valid accountId
+      if (accountId.length === 42) {
+        let dataKey;
+        const sha3Account = web3.utils.soliditySha3(accountId);
+        const sha9Account = web3.utils.soliditySha3(sha3Account, sha3Account);
+
+        // if useIdentity is specified, try to generate dataKeys with identity
+        if (runtimeConfig.useIdentity) {
+          if (!contextLessRuntime) {
+            // create a runtime without account relation, just for accesing some bcc class instances
+            contextLessRuntime = createRuntime(
+              web3,
+              dfs,
+              {
+                accountMap: {
+                  [nullAddress]: 'no-private-key-here',
+                },
+              },
+              options,
+            );
+          }
+
+          // try out several dataKey encryption salting methods and check if, generated dataKeys are
+          // correct
+          const identity = await (await contextLessRuntime).verifications
+            .getIdentityForAccount(accountId, true);
+          const encryptionSalts = [identity, accountId].filter((salt) => salt !== nullAddress);
+          // eslint-disable-next-line guard-for-in
+          for (const encryptionSalt of encryptionSalts) {
+            const saltedDataKey = web3.utils
+              .keccak256(encryptionSalt + runtimeConfig.keyConfig[accountId])
+              .replace(/0x/g, '');
+            const tempRuntime = await createRuntime(web3, dfs, {
+              accountMap: {
+                [accountId]: runtimeConfig.accountMap[accountId],
+              },
+              keyConfig: {
+                [sha3Account]: saltedDataKey,
+                [sha9Account]: saltedDataKey,
+              },
+              useIdentity: runtimeConfig.useIdentity,
+            });
+
+            if (tempRuntime.profile) {
+              dataKey = saltedDataKey;
+              break;
+            }
+          }
+        } else {
+          dataKey = web3.utils
+            .keccak256(accountId + runtimeConfig.keyConfig[accountId])
+            .replace(/0x/g, '');
+        }
+
+        if (!dataKey) {
+          throw new Error(`incorrect password for ${accountId} passed to keyConfig`);
+        }
+
+        // now add the different hashed accountids and datakeys to the runtimeconfig, if the
+        // dataKey was correct
+        runtimeConfig.keyConfig[sha3Account] = dataKey;
+        runtimeConfig.keyConfig[sha9Account] = dataKey;
+        delete runtimeConfig.keyConfig[accountId];
+      }
+    }));
+  }
+
+  return createRuntime(web3, dfs, runtimeConfig, options);
 }
 
 /**


### PR DESCRIPTION
support runtime creation with mnemonic and identity password encryption salting

- split runtime creation from keyConfig parsing
- support identity salting for encryptionKey generation for `createDefaultRuntime`
- enhance tests for checking multiple types of mnemonics
- [CORE-1276]

[CORE-1276]: https://evannetwork.atlassian.net/browse/CORE-1276