### PR TITLE
add `ensureWhitelisted` to writing operations

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,10 +1,10 @@
 # api-blockchain-core
 
-
 ## Next Version
 ### Features
 
 ### Fixes
+- add `ensureWhitelisted` to writing operations against `vade` to ensure account is allowed to do so 
 
 ### Deprecations
 

--- a/src/did/did.ts
+++ b/src/did/did.ts
@@ -341,7 +341,12 @@ export class Did extends Logger {
       const privateKey = await this.options.accountStore.getPrivateKey(
         this.options.signerIdentity.underlyingAccount,
       );
-
+      // ensure, executing identity is whitelisted
+      await this.vade.ensureWhitelisted(
+        signerIdentityDid,
+        privateKey,
+        this.options.signerIdentity.activeIdentity.replace('0x', ''),
+      );
 
       await this.vade.didUpdate(
         did,

--- a/src/verifications/verifications.ts
+++ b/src/verifications/verifications.ts
@@ -529,13 +529,23 @@ export class Verifications extends Logger {
       identity = identityContract.options.address;
     } else {
       if (this.options.vade) {
+        const privateKey = await this.options.accountStore.getPrivateKey(
+          this.options.signerIdentity.underlyingAccount,
+        );
+        const activeIdentityDid = await this.options.did.convertIdentityToDid(
+          this.config.activeIdentity,
+        );
+        // ensure, executing identity is whitelisted
+        await this.options.vade.ensureWhitelisted(
+          activeIdentityDid,
+          privateKey,
+          this.config.activeIdentity.replace('0x', ''),
+        );
         identity = (await this.options.vade.didCreate(
           'did:evan:testcore',
           JSON.stringify({
-            privateKey: await this.options.accountStore.getPrivateKey(
-              this.options.signerIdentity.underlyingAccount,
-            ),
-            identity: await this.options.did.convertIdentityToDid(this.config.activeIdentity),
+            privateKey,
+            identity: activeIdentityDid,
           }),
           '',
         )).replace(/^.*0x/, '0x');


### PR DESCRIPTION
- to ensure account is allowed to use `vade` for this
- [CORE-1666]

[CORE-1666]: https://evannetwork.atlassian.net/browse/CORE-1666